### PR TITLE
KL - Fixed footer typo

### DIFF
--- a/frontend/src/main/components/Nav/Footer.js
+++ b/frontend/src/main/components/Nav/Footer.js
@@ -7,7 +7,7 @@ export default function Footer({systemInfo}) {
         <p data-testid="footer-content">
           Organic is a project of{' '} 
           <a href="https://ucsb-cs156.github.io">CS156</a>, 
-          a course at UC Santa Barbara.  It's purpose: provide students and instructors with useful tools to manage
+          a course at UC Santa Barbara. Its purpose: provide students and instructors with useful tools to manage
           Github organizations associated with programming and software engineering courses.
           The open source code is available on
           <> </>

--- a/frontend/src/tests/components/Nav/Footer.test.js
+++ b/frontend/src/tests/components/Nav/Footer.test.js
@@ -8,7 +8,7 @@ describe("Footer tests", () => {
             <Footer systemInfo={systemInfoFixtures.showingAll}/>
         );
 
-        const expectedText = "Organic is a project of CS156, a course at UC Santa Barbara.  It's purpose: provide students and instructors with useful tools to manage Github organizations associated with programming and software engineering courses. The open source code is available on GitHub.";
+        const expectedText = "Organic is a project of CS156, a course at UC Santa Barbara.  Its purpose: provide students and instructors with useful tools to manage Github organizations associated with programming and software engineering courses. The open source code is available on GitHub.";
 
         
         const text = screen.getByTestId("footer-content");

--- a/frontend/src/tests/components/Nav/Footer.test.js
+++ b/frontend/src/tests/components/Nav/Footer.test.js
@@ -8,7 +8,7 @@ describe("Footer tests", () => {
             <Footer systemInfo={systemInfoFixtures.showingAll}/>
         );
 
-        const expectedText = "Organic is a project of CS156, a course at UC Santa Barbara.  Its purpose: provide students and instructors with useful tools to manage Github organizations associated with programming and software engineering courses. The open source code is available on GitHub.";
+        const expectedText = "Organic is a project of CS156, a course at UC Santa Barbara. Its purpose: provide students and instructors with useful tools to manage Github organizations associated with programming and software engineering courses. The open source code is available on GitHub.";
 
         
         const text = screen.getByTestId("footer-content");

--- a/src/main/resources/db/migration/changes/0005_CreateCourseTable.json
+++ b/src/main/resources/db/migration/changes/0005_CreateCourseTable.json
@@ -71,8 +71,8 @@
             ,
             "tableName": "COURSES"
           }
-        }]
-      
+        }],
+      "checksum": "8:8:a84cfd225c258a3f6470354487ae5b77"
     }
   },
   


### PR DESCRIPTION
Changed "It's" to the corrected "Its". 
Deployed at: https://organic-kjlee2504-dev.dokku-10.cs.ucsb.edu/
<img width="1271" alt="Screenshot 2024-02-26 at 10 57 21 PM" src="https://github.com/ucsb-cs156-w24/proj-organic-w24-6pm-2/assets/124764434/f9ecaba2-283f-4213-9c6e-30b0d3c3c3bc">
Closes #9 